### PR TITLE
Add pip install wheel to fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install --upgrade wheel
 
     - name: Install package
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,14 +42,6 @@ jobs:
     - name: Test with pytest
       run: |
         coverage run -m pytest tests/
-    - name: Upload coverage to Coveralls
-      if: ${{ github.ref == 'refs/heads/main' }}
-      run: |
-        coveralls --service=github
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-        COVERALLS_PARALLEL: true
 
     - name: Check black formatting 
       uses: psf/black@stable
@@ -58,22 +50,3 @@ jobs:
         version: "22.10.0"
     - name: Check isort
       uses: isort/isort-action@master
-
-  coveralls:
-
-    name: Indicate completion to coveralls.io
-    needs: test
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Install dependencies
-      if: ${{ github.ref == 'refs/heads/main' }}
-      run: |
-        python -m pip install --upgrade pip
-        pip install coveralls
-    - name: Finished
-      if: ${{ github.ref == 'refs/heads/main' }}
-      run: |
-        coveralls --service=github --finish
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Upload coverage to Coveralls
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |
-        coveralls -i --service=github
+        coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
@@ -74,6 +74,6 @@ jobs:
     - name: Finished
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |
-        coveralls -i --service=github --finish
+        coveralls --service=github --finish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Publish run started failing (https://github.com/google/unisim/actions/runs/9179734788) due to error: invalid command 'bdist_wheel' when running "python setup.py sdist bdist_wheel".

Uploading coverage to coveralls in test workflow also failing so temporarily removing (opened new issue to track adding it back).