### PR TITLE
fix: Use logging instead of print statements for backend loading and UniSim data storage messages

### DIFF
--- a/unisim/backend/load_backend.py
+++ b/unisim/backend/load_backend.py
@@ -5,6 +5,7 @@
 # https://opensource.org/licenses/MIT.
 
 import os
+import logging
 
 from ..config import get_accelerator, get_backend, set_accelerator, set_backend
 from ..enums import AcceleratorType, BackendType
@@ -83,5 +84,5 @@ elif get_backend() == BackendType.tf:
 else:
     raise ValueError(f"Unknown backend {get_backend()}")
 
-print("INFO: Loaded backend")
-print(f"INFO: Using {get_backend().name.upper()} with {get_accelerator().name.upper()}")
+logging.info("Loaded backend")
+logging.info("Using %s with %s", get_backend().name.upper(), get_accelerator().name.upper())

--- a/unisim/backend/load_backend.py
+++ b/unisim/backend/load_backend.py
@@ -4,8 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-import os
 import logging
+import os
 
 from ..config import get_accelerator, get_backend, set_accelerator, set_backend
 from ..enums import AcceleratorType, BackendType

--- a/unisim/unisim.py
+++ b/unisim/unisim.py
@@ -4,8 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-from abc import ABC
 import logging
+from abc import ABC
 from typing import Any, Dict, List, Sequence
 
 import numpy as np

--- a/unisim/unisim.py
+++ b/unisim/unisim.py
@@ -5,6 +5,7 @@
 # https://opensource.org/licenses/MIT.
 
 from abc import ABC
+import logging
 from typing import Any, Dict, List, Sequence
 
 import numpy as np
@@ -81,14 +82,14 @@ class UniSim(ABC):
         self.verbose = verbose
 
         if self.store_data:
-            print("INFO: UniSim is storing a copy of the indexed data")
-            print("INFO: If you are using large data corpus, consider disabling this behavior using store_data=False")
+            logging.info("UniSim is storing a copy of the indexed data")
+            logging.info("If you are using large data corpus, consider disabling this behavior using store_data=False")
         else:
-            print("INFO: UniSim is not storing a copy of the indexed data to save memory")
-            print("INFO: If you want to store a copy of the data, use store_data=True")
+            logging.info("UniSim is not storing a copy of the indexed data to save memory")
+            logging.info("If you want to store a copy of the data, use store_data=True")
 
         if use_accelerator and get_accelerator() == AcceleratorType.cpu:
-            print("INFO: Accelerator is not available, using CPU")
+            logging.info("Accelerator is not available, using CPU")
             self.use_accelerator = False
 
         # internal state


### PR DESCRIPTION
The print messages are disruptive for any CLI tooling that leverages unisim. The standard python logging library is the way to do this as it can be configued to log both to files or the terminal.